### PR TITLE
fix: create output directory before merging libs

### DIFF
--- a/merge_static_lib.sh
+++ b/merge_static_lib.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 cd $1
+mkdir -p mpp
 rm -rf mpp/lib'$2$'.a
 
 SCRIPT=$'CREATE mpp/lib'$2$'.a\n'


### PR DESCRIPTION
## Summary
- ensure merge_static_lib.sh creates mpp directory before attempting to remove or create librockchip_mpp.a

## Testing
- `bash -n merge_static_lib.sh`
- run merge_static_lib.sh against sample libs to confirm lib creation


------
https://chatgpt.com/codex/tasks/task_e_68c01b4fea6c832f90e1b6bc30a4349a